### PR TITLE
Fix JSON format at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Rankin is, in addition to the command-line configuration parameters described ab
           "weight": 1
         },
         {
-          "label":"count-default"
+          "label":"count-default",
           "name": "count",
           "weight": 2,
           "sla": 200


### PR DESCRIPTION
Hi,

I was trying to run rankin with the configuration JSON provided at README but failed. The command said `Error loading the configuration file ./sample.json: Unexpected string`.

I dig into it and found the JSON format is not correct. The PR fixes the issue.

Thanks.